### PR TITLE
Allow string-valued axes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.acqengj</groupId>
     <artifactId>AcqEngJ</artifactId>
-    <version>0.20.0</version>
+    <version>0.21.0</version>
     <packaging>jar</packaging>
      <name>AcqEngJ</name>
     <description>Java-based Acquisition engine for Micro-Manager</description>

--- a/src/main/java/org/micromanager/acqj/internal/Engine.java
+++ b/src/main/java/org/micromanager/acqj/internal/Engine.java
@@ -21,7 +21,6 @@ package org.micromanager.acqj.internal;
  * the editor.
  */
 import org.micromanager.acqj.api.AcquisitionAPI;
-import org.micromanager.acqj.main.Acquisition;
 import org.micromanager.acqj.main.AcquisitionEvent;
 import org.micromanager.acqj.api.AcquisitionHook;
 
@@ -470,10 +469,10 @@ public class Engine {
             DoubleVector xSequence = event.isXYSequenced() ? new DoubleVector() : null;
             DoubleVector ySequence = event.isXYSequenced() ? new DoubleVector() : null;
             DoubleVector exposureSequence_ms =event.isExposureSequenced() ? new DoubleVector() : null;
-            String group = event.getSequence().get(0).getChannelGroup();
-            Configuration config = event.getSequence().get(0).getChannelConfig() == null ? null :
-                    core_.getConfigData(group, event.getSequence().get(0).getChannelConfig());
-            LinkedList<StrVector> propSequences = event.isChannelSequenced() ? new LinkedList<StrVector>() : null;
+            String group = event.getSequence().get(0).getConfigGroup();
+            Configuration config = event.getSequence().get(0).getConfigPreset() == null ? null :
+                    core_.getConfigData(group, event.getSequence().get(0).getConfigPreset());
+            LinkedList<StrVector> propSequences = event.isConfigGroupSequenced() ? new LinkedList<StrVector>() : null;
             for (AcquisitionEvent e : event.getSequence()) {
                if (zSequence != null) {
                   zSequence.add(e.getZPosition());
@@ -497,7 +496,7 @@ public class Engine {
                         propSequences.add(new StrVector());
                      }
                      Configuration channelPresetConfig = core_.getConfigData(group,
-                             e.getChannelConfig());
+                             e.getConfigPreset());
                      String propValue = channelPresetConfig.getSetting(deviceName, propName).getPropertyValue();
                      propSequences.get(i).add(propValue);
                   }
@@ -513,7 +512,7 @@ public class Engine {
             if (event.isZSequenced()) {
                core_.loadStageSequence(zStage, zSequence);
             }
-            if (event.isChannelSequenced()) {
+            if (event.isConfigGroupSequenced()) {
                for (int i = 0; i < config.size(); i++) {
                   PropertySetting ps = config.getSetting(i);
                   String deviceName = ps.getDeviceLabel();
@@ -618,11 +617,10 @@ public class Engine {
          @Override
          public void run() {
             try {
-               if (event.isChannelSequenced()) {
+               if (event.isConfigGroupSequenced()) {
                   //Channels
-                  String group = event.getChannelGroup();
-                  Configuration config = core_.getConfigData(group,
-                          event.getChannelConfig());
+                  String group = event.getConfigGroup();
+                  Configuration config = core_.getConfigData(group, event.getConfigPreset());
                   for (int i = 0; i < config.size(); i++) {
                      PropertySetting ps = config.getSetting(i);
                      String deviceName = ps.getDeviceLabel();
@@ -632,11 +630,11 @@ public class Engine {
                } else {
                   //Get the values of current channel, pulling from the first event in a sequence if one is present
                   String currentConfig = event.getSequence() == null ?
-                          event.getChannelConfig() : event.getSequence().get(0).getChannelConfig();
+                          event.getConfigPreset() : event.getSequence().get(0).getConfigPreset();
                   String currentGroup = event.getSequence() == null ?
-                          event.getChannelGroup() : event.getSequence().get(0).getChannelGroup();
+                          event.getConfigGroup() : event.getSequence().get(0).getConfigGroup();
                   String previousConfig = lastEvent_ == null ? null : lastEvent_.getSequence() == null ?
-                          lastEvent_.getChannelConfig() : lastEvent_.getSequence().get(0).getChannelConfig();
+                          lastEvent_.getConfigPreset() : lastEvent_.getSequence().get(0).getConfigPreset();
 
                   boolean newChannel = currentConfig != null && (previousConfig == null || !previousConfig.equals(currentConfig));
                   if ( newChannel ) {
@@ -774,10 +772,10 @@ public class Engine {
          }
 
          //check all properties in channel
-         if (e1.getChannelConfig() != null && e2.getChannelConfig() != null
-                 && !e1.getChannelConfig().equals(e2.getChannelConfig())) {
+         if (e1.getConfigPreset() != null && e2.getConfigPreset() != null
+                 && !e1.getConfigPreset().equals(e2.getConfigPreset())) {
             //check all properties in the channel
-            Configuration config1 = core_.getConfigData(e1.getChannelGroup(), e1.getChannelConfig());
+            Configuration config1 = core_.getConfigData(e1.getConfigGroup(), e1.getConfigPreset());
             for (int i = 0; i < config1.size(); i++) {
                PropertySetting ps = config1.getSetting(i);
                String deviceName = ps.getDeviceLabel();

--- a/src/main/java/org/micromanager/acqj/main/AcqEngMetadata.java
+++ b/src/main/java/org/micromanager/acqj/main/AcqEngMetadata.java
@@ -883,11 +883,11 @@ public class AcqEngMetadata {
       }
    }
    
-    public static HashMap<String, Integer> getAxes(JSONObject tags) {
+    public static HashMap<String, Object> getAxes(JSONObject tags) {
       try {
          JSONObject axes = tags.getJSONObject(AXES);
          Iterator<String> iter = axes.keys();
-         HashMap<String, Integer> axesMap = new HashMap<String, Integer>();
+         HashMap<String, Object> axesMap = new HashMap<String, Object>();
          while (iter.hasNext()) {
             String key = iter.next();
             axesMap.put(key, axes.getInt(key));        
@@ -898,7 +898,10 @@ public class AcqEngMetadata {
       }
    }
 
-   public static void setAxisPosition(JSONObject tags, String axis, int position) {
+   public static void setAxisPosition(JSONObject tags, String axis, Object position) {
+      if (!(position instanceof String || position instanceof Integer)) {
+         throw new RuntimeException("position must be String or Integer");
+      }
       try {
          tags.getJSONObject(AXES).put(axis, position);
       } catch (JSONException ex) {

--- a/src/main/java/org/micromanager/acqj/main/AcqEngMetadata.java
+++ b/src/main/java/org/micromanager/acqj/main/AcqEngMetadata.java
@@ -116,7 +116,7 @@ public class AcqEngMetadata {
          AcqEngMetadata.createAxes(tags);
 
          ////////  Channels /////////
-         String channelName = event.getChannelConfig() == null ? "" : event.getChannelConfig() ;
+         String channelName = event.getConfigPreset() == null ? "" : event.getConfigPreset() ;
          if (Engine.getCore().getNumberOfCameraChannels() > 1) {
             channelName = channelName.length() > 0 ? channelName + "_" +
                     Engine.getCore().getCameraChannelName(camChannelIndex) : Engine.getCore().getCameraChannelName(camChannelIndex);
@@ -890,7 +890,7 @@ public class AcqEngMetadata {
          HashMap<String, Object> axesMap = new HashMap<String, Object>();
          while (iter.hasNext()) {
             String key = iter.next();
-            axesMap.put(key, axes.getInt(key));        
+            axesMap.put(key, axes.get(key));
          }
          return axesMap;
       } catch (JSONException ex) {

--- a/src/main/java/org/micromanager/acqj/main/Acquisition.java
+++ b/src/main/java/org/micromanager/acqj/main/Acquisition.java
@@ -16,6 +16,7 @@
 //
 package org.micromanager.acqj.main;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
@@ -44,7 +45,6 @@ public class Acquisition implements AcquisitionAPI {
    private JSONObject summaryMetadata_;
    private long startTime_ms_ = -1;
    private volatile boolean paused_ = false;
-   private CopyOnWriteArrayList<String> channelNames_ = new CopyOnWriteArrayList<String>();
    protected DataSink dataSink_;
    private Consumer<JSONObject> summaryMDAdder_;
    final public CMMCore core_;
@@ -296,15 +296,7 @@ public class Acquisition implements AcquisitionAPI {
          dataSink_.finish();
          eventsFinished_ = true; //should have already been done, but just in case
       } else {
-         //Now that all data processors have run, the channel index can be inferred
-         //based on what channels show up at runtime
-         String channelName = AcqEngMetadata.getChannelName(image.tags);
-         if (!channelNames_.contains(channelName)) {
-            channelNames_.add(channelName);
-         }
-         AcqEngMetadata.setAxisPosition(image.tags, AcqEngMetadata.CHANNEL_AXIS,
-                 channelNames_.indexOf(channelName));
-         //this method doesnt return until all images have been written to disk
+         //this method doesn't return until all images have been written to disk
          dataSink_.putImage(image);
       }
    }

--- a/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
+++ b/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
@@ -46,11 +46,11 @@ public class AcquisitionEvent {
    public Acquisition acquisition_;
 
    //For encoded time, z indices (or other generic axes)
-   //XY position and channel indices should not be encoded because acq engine
+   //XY position indices should not be encoded because acq engine
    //will dynamically infer them at runtime
    private HashMap<String, Object> axisPositions_ = new HashMap<String, Object>();
 
-   private String channelGroup_, channelConfig_ = null;
+   private String configGroup_, configPreset_ = null;
    private Double exposure_ = null; //leave null to keep exposaure unchanged
 
    private Long miniumumStartTime_ms_; //For pausing between time points
@@ -73,7 +73,7 @@ public class AcquisitionEvent {
 
    //for hardware sequencing
    private List<AcquisitionEvent> sequence_ = null;
-   private boolean xySequenced_ = false, zSequenced_ = false, exposureSequenced_ = false, channelSequenced_ = false;
+   private boolean xySequenced_ = false, zSequenced_ = false, exposureSequenced_ = false, configGroupSequenced_ = false;
 
    //To specify end of acquisition or end of sequence
    private SpecialFlag specialFlag_;
@@ -112,13 +112,13 @@ public class AcquisitionEvent {
          if (sequence_.get(i).exposure_ != null) {
             exposureSet.add(sequence_.get(i).getExposure());
          }
-         if (sequence_.get(i).channelConfig_ != null) {
-            configSet.add(sequence_.get(i).getChannelConfig());
+         if (sequence_.get(i).configPreset_ != null) {
+            configSet.add(sequence_.get(i).getConfigPreset());
          }
       }
       //TODO: add SLM sequences
       exposureSequenced_ = exposureSet.size() > 1;
-      channelSequenced_ = configSet.size() > 1;
+      configGroupSequenced_ = configSet.size() > 1;
       xySequenced_ = xPosSet.size() > 1 && yPosSet.size() > 1;
       zSequenced_ = zPosSet.size() > 1;
    }
@@ -126,8 +126,8 @@ public class AcquisitionEvent {
    public AcquisitionEvent copy() {
       AcquisitionEvent e = new AcquisitionEvent(this.acquisition_);
       e.axisPositions_ = (HashMap<String, Object>) axisPositions_.clone();
-      e.channelConfig_ = channelConfig_;
-      e.channelGroup_ = channelConfig_;
+      e.configPreset_ = configPreset_;
+      e.configGroup_ = configPreset_;
       e.zPosition_ = zPosition_;
       e.xPosition_ = xPosition_;
       e.yPosition_ = yPosition_;
@@ -156,11 +156,11 @@ public class AcquisitionEvent {
             json.put("min_start_time", e.miniumumStartTime_ms_ / 1000);
          }
 
-         if (e.hasChannel()) {
-            JSONObject channel = new JSONObject();
-            channel.put("group", e.channelGroup_);
-            channel.put("config", e.channelConfig_);
-            json.put("channel", channel);
+         if (e.hasConfigGroup()) {
+            JSONArray configGroup = new JSONArray();
+            configGroup.put( e.configGroup_);
+            configGroup.put( e.configPreset_);
+            json.put("config_group", configGroup);
          }
 
          if (e.exposure_ != null) {
@@ -234,7 +234,7 @@ public class AcquisitionEvent {
             JSONObject axes = json.getJSONObject("axes");
             axes.keys().forEachRemaining((String axisLabel) -> {
                try {
-                  event.axisPositions_.put(axisLabel, axes.getInt(axisLabel));
+                  event.axisPositions_.put(axisLabel, axes.get(axisLabel));
                } catch (JSONException ex) {
                   throw new RuntimeException(ex);
                }
@@ -245,10 +245,10 @@ public class AcquisitionEvent {
             event.miniumumStartTime_ms_ = (long) (json.getDouble("min_start_time") * 1000);
          }
 
-         //channel name
-         if (json.has("channel")) {
-            event.channelConfig_ = json.getJSONObject("channel").getString("config");
-            event.channelGroup_ = json.getJSONObject("channel").getString("group");
+         // Config group (usually this is a channel, but doesnt have to be)
+         if (json.has("config_group")) {
+            event.configGroup_ = json.getJSONArray("config_group").getString(0);
+            event.configPreset_ = json.getJSONArray("config_group").getString(1);
          }
          if (json.has("exposure")) {
             event.exposure_ = json.getDouble("exposure");
@@ -356,28 +356,28 @@ public class AcquisitionEvent {
       } else if (gridRow_ != null && gridCol_ != null) {
          return true;
       } else {
-         return channelConfig_ != null || axisPositions_.keySet().size() > 0;
+         return configPreset_ != null || axisPositions_.keySet().size() > 0;
       }
    }
 
-   public boolean hasChannel() {
-      return channelConfig_ != null && channelGroup_ != null;
+   public boolean hasConfigGroup() {
+      return configPreset_ != null && configGroup_ != null;
    }
 
-   public String getChannelConfig() {
-      return channelConfig_;
+   public String getConfigPreset() {
+      return configPreset_;
    }
 
-   public String getChannelGroup() {
-      return channelGroup_;
+   public String getConfigGroup() {
+      return configGroup_;
    }
 
-   public void setChannelConfig(String config) {
-      channelConfig_ = config;
+   public void setConfigPreset(String config) {
+      configPreset_ = config;
    }
 
-   public void setChannelGroup(String group) {
-      channelGroup_ = group;
+   public void setConfigGroup(String group) {
+      configGroup_ = group;
    }
 
    public Double getExposure() {
@@ -401,8 +401,8 @@ public class AcquisitionEvent {
       return axisPositions_.keySet();
    }
 
-   public void setAxisPosition(String label, int index) {
-      axisPositions_.put(label, index);
+   public void setAxisPosition(String label, Object position) {
+      axisPositions_.put(label, position);
    }
 
    public Object getAxisPosition(String label) {
@@ -414,6 +414,10 @@ public class AcquisitionEvent {
 
    public void setTimeIndex(int index) {
       setAxisPosition(AcqEngMetadata.TIME_AXIS, index);
+   }
+
+   public void setChannelName(String name) {
+      setAxisPosition(AcqEngMetadata.CHANNEL_AXIS, name);
    }
 
    public Object getSLMImage() {
@@ -479,8 +483,8 @@ public class AcquisitionEvent {
       return exposureSequenced_;
    }
 
-   public boolean isChannelSequenced() {
-      return channelSequenced_;
+   public boolean isConfigGroupSequenced() {
+      return configGroupSequenced_;
    }
 
    public boolean isXYSequenced() {

--- a/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
+++ b/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
@@ -48,7 +48,7 @@ public class AcquisitionEvent {
    //For encoded time, z indices (or other generic axes)
    //XY position and channel indices should not be encoded because acq engine
    //will dynamically infer them at runtime
-   private HashMap<String, Integer> axisPositions_ = new HashMap<String, Integer>();
+   private HashMap<String, Object> axisPositions_ = new HashMap<String, Object>();
 
    private String channelGroup_, channelConfig_ = null;
    private Double exposure_ = null; //leave null to keep exposaure unchanged
@@ -125,7 +125,7 @@ public class AcquisitionEvent {
 
    public AcquisitionEvent copy() {
       AcquisitionEvent e = new AcquisitionEvent(this.acquisition_);
-      e.axisPositions_ = (HashMap<String, Integer>) axisPositions_.clone();
+      e.axisPositions_ = (HashMap<String, Object>) axisPositions_.clone();
       e.channelConfig_ = channelConfig_;
       e.channelGroup_ = channelConfig_;
       e.zPosition_ = zPosition_;
@@ -405,7 +405,7 @@ public class AcquisitionEvent {
       axisPositions_.put(label, index);
    }
 
-   public Integer getAxisPosition(String label) {
+   public Object getAxisPosition(String label) {
       if (!axisPositions_.containsKey(label)) {
          return null;
       }
@@ -428,11 +428,11 @@ public class AcquisitionEvent {
    }
 
    public Integer getTIndex() {
-      return getAxisPosition(AcqEngMetadata.TIME_AXIS);
+      return (Integer) getAxisPosition(AcqEngMetadata.TIME_AXIS);
    }
 
    public Integer getZIndex() {
-      return getAxisPosition(AcqEngMetadata.Z_AXIS);
+      return (Integer) getAxisPosition(AcqEngMetadata.Z_AXIS);
    }
 
    public static AcquisitionEvent createAcquisitionFinishedEvent(AcquisitionAPI acq) {

--- a/src/main/java/org/micromanager/acqj/util/AcqEventModules.java
+++ b/src/main/java/org/micromanager/acqj/util/AcqEventModules.java
@@ -95,8 +95,9 @@ public class AcqEventModules {
             @Override
             public AcquisitionEvent next() {
                AcquisitionEvent channelEvent = event.copy();
-               channelEvent.setChannelGroup(channelList.get(index).group_);
-               channelEvent.setChannelConfig(channelList.get(index).config_);
+               channelEvent.setConfigGroup(channelList.get(index).group_);
+               channelEvent.setConfigPreset(channelList.get(index).config_);
+               channelEvent.setChannelName(channelList.get(index).config_);
                boolean hasZOffsets = channelList.stream().map(t -> t.offset_).
                        filter(t -> t != 0).collect(Collectors.toList()).size() > 0;
                Double zPos;


### PR DESCRIPTION
which helps enable the separation of how to store different channels (i.e. axes) from how to collect them  (i.e. config groups)