### PR TITLE
Adds a way to end an  event "branch" using null as a signal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.acqengj</groupId>
     <artifactId>AcqEngJ</artifactId>
-    <version>0.26.5</version>
+    <version>0.26.6</version>
     <packaging>jar</packaging>
      <name>AcqEngJ</name>
     <description>Java-based Acquisition engine for Micro-Manager</description>
@@ -24,7 +24,7 @@
        <developer>
           <id>nicost</id>
           <name>Nico Stuurman</name>
-          <organization>UCSF/HHMI</organization>
+          <organization>Altos Labs</organization>
        </developer>
     </developers>
 

--- a/src/main/java/org/micromanager/acqj/internal/Engine.java
+++ b/src/main/java/org/micromanager/acqj/internal/Engine.java
@@ -122,6 +122,11 @@ public class Engine {
             AcquisitionAPI acq = null;
             while (eventIterator.hasNext()) {
                AcquisitionEvent event = eventIterator.next();
+               // Some iterators can return null, they still may have more events, but want to
+               // skip this one.
+               if (event == null) {
+                  continue;
+               }
                acq = event.acquisition_;
                if (acq.isDebugMode()) {
                   core_.logMessage("got event: " + event.toString()  );

--- a/src/main/java/org/micromanager/acqj/util/AcquisitionEventIterator.java
+++ b/src/main/java/org/micromanager/acqj/util/AcquisitionEventIterator.java
@@ -41,16 +41,20 @@ public class AcquisitionEventIterator implements Iterator<AcquisitionEvent> {
 
    @Override
    public AcquisitionEvent next() {
-      AcquisitionEvent next = currentLeaf_.iterator.next();
-      //Move to new branch or determine that all branches are exhausted
-      //May need to try ascent and descent multiple times in case a terminal iterator produces no events?
+      AcquisitionEvent next = null;
+      while (next == null && currentLeaf_.iterator.hasNext()) {
+         next = currentLeaf_.iterator.next();
+      }
+
+      // Move to new branch or determine that all branches are exhausted
+      // May need to try ascent and descent multiple times in case a terminal iterator
+      // produces no events?
       while (!currentLeaf_.iterator.hasNext()) {
          //ascend to node where next valid branch can be found
          while (!currentLeaf_.iterator.hasNext()) {
             currentLeaf_ = currentLeaf_.parent;
             if (currentLeaf_ == null) {
                eventsExhausted_ = true;
-//               System.out.println(next);
                if (eventMonitorFunction_ == null) {
                   return next;
                }
@@ -59,7 +63,7 @@ public class AcquisitionEventIterator implements Iterator<AcquisitionEvent> {
          }
          descendNewBranch();
       }
-//      System.out.println(next);
+
       if (eventMonitorFunction_ == null) {
          return next;
       }


### PR DESCRIPTION
Iterators can now return a null event, effectively stopping traversal of this part of the tree, and continuation to the next item in the iterator.  This mechanism is used in a corresponding PR in micro-manager for channels to skip frames and skip doing Z stacks.  There may be other solutions to this problem, but this approach seems relatively straight forward.  Changes in AcqEngJ are quite minimal, mainly avoiding null pointer exceptions.