### PR TITLE
Stop devices running sequences at the end of the sequence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.acqengj</groupId>
     <artifactId>AcqEngJ</artifactId>
-    <version>0.28.0</version>
+    <version>0.28.1</version>
     <packaging>jar</packaging>
      <name>AcqEngJ</name>
     <description>Java-based Acquisition engine for Micro-Manager</description>

--- a/src/main/java/org/micromanager/acqj/internal/Engine.java
+++ b/src/main/java/org/micromanager/acqj/internal/Engine.java
@@ -17,8 +17,6 @@
 package org.micromanager.acqj.internal;
 
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import mmcorej.org.json.JSONException;
 import org.micromanager.acqj.api.AcquisitionAPI;
 import org.micromanager.acqj.main.AcquisitionEvent;
@@ -348,6 +346,7 @@ public class Engine {
                while (core_.isSequenceRunning()) {
                   Thread.sleep(2);
                }
+               stopHardwareSequences(hardwareSequencesInProgress);
             }
          }
 
@@ -564,13 +563,13 @@ public class Engine {
                                  HardwareSequences hardwareSequencesInProgress) {
       if (event.acquisition_.isAbortRequested()) {
          if (hardwareSequencesInProgress != null) {
-            abortHardwareSequences(hardwareSequencesInProgress);
+            stopHardwareSequences(hardwareSequencesInProgress);
          }
          return;
       }
    }
 
-   private void abortHardwareSequences(HardwareSequences hardwareSequencesInProgress) {
+   private void stopHardwareSequences(HardwareSequences hardwareSequencesInProgress) {
       // Stop any hardware sequences
       for (String deviceName : hardwareSequencesInProgress.deviceNames) {
          try {


### PR DESCRIPTION
The API does not specify that these sequences should stop by themselves, and some devices continue to allow circular progression.  Not stopping them leaves the hardware in an unusable state.  Stopping them when they are already stopped should be harmless.  Tested with hardware, and this fixed an issue I had with the NI adapter.