### PR TITLE
Set exposure time for event sequences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.acqengj</groupId>
     <artifactId>AcqEngJ</artifactId>
-    <version>0.28.1</version>
+    <version>0.28.2</version>
     <packaging>jar</packaging>
      <name>AcqEngJ</name>
     <description>Java-based Acquisition engine for Micro-Manager</description>

--- a/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
+++ b/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
@@ -129,6 +129,10 @@ public class AcquisitionEvent {
       configGroupSequenced_ = configSet.size() > 1;
       xySequenced_ = xPosSet.size() > 1 && yPosSet.size() > 1;
       zSequenced_ = zPosSet.size() > 1;
+      // set exposure time if it is provided and exposure is not sequenced
+      if (sequence_.get(0).exposure_ != null && !exposureSequenced_) {
+         exposure_ = sequence.get(0).exposure_;
+      };
    }
 
    public AcquisitionEvent copy() {


### PR DESCRIPTION
This PR fixes https://github.com/micro-manager/pycro-manager/issues/622. The exposure time is now correctly set for event sequences.