### PR TITLE
Add position name to image metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.acqengj</groupId>
     <artifactId>AcqEngJ</artifactId>
-    <version>0.28.2</version>
+    <version>0.29.0</version>
     <packaging>jar</packaging>
      <name>AcqEngJ</name>
     <description>Java-based Acquisition engine for Micro-Manager</description>

--- a/src/main/java/org/micromanager/acqj/main/AcqEngMetadata.java
+++ b/src/main/java/org/micromanager/acqj/main/AcqEngMetadata.java
@@ -127,6 +127,9 @@ public class AcqEngMetadata {
          if (event.getZPosition() != null) {
             AcqEngMetadata.setStageZIntended(tags, event.getZPosition());
          }
+         if (event.getPositionName() != null) {
+            AcqEngMetadata.setPositionName(tags, event.getPositionName());
+         }
 
          if (event.getSequence() != null) {
             //Dont add the event to image metadata if it is a sequence, because it could potentially be very large

--- a/src/main/java/org/micromanager/acqj/main/AcqEngMetadata.java
+++ b/src/main/java/org/micromanager/acqj/main/AcqEngMetadata.java
@@ -80,6 +80,7 @@ public class AcqEngMetadata {
    public static final String CHANNEL_AXIS = "channel";
    public static final String TIME_AXIS = "time";
    public static final String Z_AXIS = "z";
+   public static final String POSITION_AXIS = "position";
    public static final String TAGS = "tags";
 
    private static final String ACQUISITION_EVENT = "Event";

--- a/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
+++ b/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
@@ -61,7 +61,6 @@ public class AcquisitionEvent {
 
    //positions for devices that are generically hardcoded into MMCore
    private Double zPosition_ = null, xPosition_ = null, yPosition_ = null;
-   private String positionName_ = null;
 
    //TODO: SLM, Galvo, etc
 
@@ -147,7 +146,6 @@ public class AcquisitionEvent {
       e.stageDeviceNamesToAxisNames_ = new HashMap<>(stageDeviceNamesToAxisNames_);
       e.xPosition_ = xPosition_;
       e.yPosition_ = yPosition_;
-      e.positionName_ = positionName_;
       e.miniumumStartTime_ms_ = miniumumStartTime_ms_;
       e.slmImage_ = slmImage_;
       e.acquireImage_ = acquireImage_;
@@ -328,10 +326,6 @@ public class AcquisitionEvent {
          }
          if (json.has("y")) {
             event.yPosition_ = json.getDouble("y");
-         }
-
-         if (event.getAxisPosition("position") instanceof String) {
-            event.positionName_ = (String) event.getAxisPosition("position");
          }
 
          if (json.has("slm_pattern")) {
@@ -648,6 +642,13 @@ public class AcquisitionEvent {
    }
 
    public String getPositionName() {
+      String positionName_ = null;
+      Object axisPosition_ = getAxisPosition("position");
+
+      if (axisPosition_ instanceof String) {
+         positionName_ = (String) axisPosition_;
+      }
+
       return positionName_;
    }
 

--- a/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
+++ b/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
@@ -643,7 +643,7 @@ public class AcquisitionEvent {
 
    public String getPositionName() {
       String positionName_ = null;
-      Object axisPosition_ = getAxisPosition("position");
+      Object axisPosition_ = getAxisPosition(AcqEngMetadata.POSITION_AXIS);
 
       if (axisPosition_ instanceof String) {
          positionName_ = (String) axisPosition_;

--- a/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
+++ b/src/main/java/org/micromanager/acqj/main/AcquisitionEvent.java
@@ -61,6 +61,8 @@ public class AcquisitionEvent {
 
    //positions for devices that are generically hardcoded into MMCore
    private Double zPosition_ = null, xPosition_ = null, yPosition_ = null;
+   private String positionName_ = null;
+
    //TODO: SLM, Galvo, etc
 
    private HashMap<String, Double> stageCoordinates_ = new HashMap<String, Double>();
@@ -145,6 +147,7 @@ public class AcquisitionEvent {
       e.stageDeviceNamesToAxisNames_ = new HashMap<>(stageDeviceNamesToAxisNames_);
       e.xPosition_ = xPosition_;
       e.yPosition_ = yPosition_;
+      e.positionName_ = positionName_;
       e.miniumumStartTime_ms_ = miniumumStartTime_ms_;
       e.slmImage_ = slmImage_;
       e.acquireImage_ = acquireImage_;
@@ -325,6 +328,10 @@ public class AcquisitionEvent {
          }
          if (json.has("y")) {
             event.yPosition_ = json.getDouble("y");
+         }
+
+         if (event.getAxisPosition("position") instanceof String) {
+            event.positionName_ = (String) event.getAxisPosition("position");
          }
 
          if (json.has("slm_pattern")) {
@@ -640,6 +647,9 @@ public class AcquisitionEvent {
       return yPosition_;
    }
 
+   public String getPositionName() {
+      return positionName_;
+   }
 
    public void setX(double x) {
       xPosition_ = x;


### PR DESCRIPTION
This PR adds the position name to the image metadata if a string label is used as the event position axis, e.g.

```python
{'axes': {'position': 'Pos0'}, 'x': 0, 'y': 0}
```

The saved image will have a `PositionName: "Pos0"` entry in the metadata. This is consistent with the Micro-manager MDA metadata format.

pycromanager-acquired images also have a `Position: "Default"` metadata field which may cause some confusion. I believe this field comes with the tagged image and is not present in MDA-acquired images. I'm fine with leaving it as it, but I'm also curious where it comes from and if we can remove it in certain cases.