### PR TITLE
Log missing images in in core log rather than throwing exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.acqengj</groupId>
     <artifactId>AcqEngJ</artifactId>
-    <version>0.30.0</version>
+    <version>0.30.1</version>
     <packaging>jar</packaging>
      <name>AcqEngJ</name>
     <description>Java-based Acquisition engine for Micro-Manager</description>

--- a/src/main/java/org/micromanager/acqj/internal/Engine.java
+++ b/src/main/java/org/micromanager/acqj/internal/Engine.java
@@ -484,7 +484,9 @@ public class Engine {
                      } catch (Exception e) {
                         //continue waiting
                         if (!core_.isSequenceRunning() && core_.getRemainingImageCount() == 0) {
-                           throw new RuntimeException("Expected images did not arrive in circular buffer");
+//                           throw new RuntimeException("Expected images did not arrive in circular buffer");
+                           core_.logMessage("Error: Expected number of images did not arrive in circular buffer", false);
+                           return;
                         }
                      }
                   } else {


### PR DESCRIPTION
This is my hack to address https://github.com/micro-manager/pycro-manager/issues/664. This allows me to call `mmc.stop_sequence_acquisition()` and then send a new batch of events if the camera drops a frame (rather than using `acq.abort()`). I expect we can find a cleaner solution, but this works for me for now.