### PR TITLE
Engine: avoid hardware errors while running sequences.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.acqengj</groupId>
     <artifactId>AcqEngJ</artifactId>
-    <version>0.34.0</version>
+    <version>0.34.1</version>
     <packaging>jar</packaging>
      <name>AcqEngJ</name>
     <description>Java-based Acquisition engine for Micro-Manager</description>


### PR DESCRIPTION
I encountered two problems: the NIDAQ board did not like to load a sequence while a sequence was still running.  Stopping the sequence before loading it fixed that one.  I believe that it should be possible to avoid re-loading the exact same sequence all together. We could remember the previous sequence and if this one is identical,  skip loading.   

The other problem was that the prepareSequenceAcquistion call throws errors if the camera acquisition is still running.
I am a bit surprised that code elsewhere is not checking for this. The way my PR is now waiting for the sequence to end is ugly, but I do not know of a better way.  The upshot of all of this, is that this engine now has much less dead time between acquiring two volumes than the Clojure engine, which is very cool and useful.