### PR TITLE
Explicitly stop hardware sequences once all images are acquired.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.acqengj</groupId>
     <artifactId>AcqEngJ</artifactId>
-    <version>0.34.2</version>
+    <version>0.34.3</version>
     <packaging>jar</packaging>
      <name>AcqEngJ</name>
     <description>Java-based Acquisition engine for Micro-Manager</description>

--- a/src/main/java/org/micromanager/acqj/internal/Engine.java
+++ b/src/main/java/org/micromanager/acqj/internal/Engine.java
@@ -595,6 +595,9 @@ public class Engine {
             correspondingEvent.acquisition_.addToOutput(ti);
          }
       }
+      // Most devices loop sequences, and need to be stopped explicitly
+      // this is not the most pleasant place to put this call, but I can not find anything better.
+      stopHardwareSequences(hardwareSequencesInProgress);
 
       if (timeout) {
          throw new TimeoutException("Timeout waiting for images to arrive in circular buffer");


### PR DESCRIPTION
The core sequence API is vague about desired device behavior at the end of a sequence.  Many devices loop sequences, i.e. continue forever until stopped. This behavior (if explicit) could possible be leveraged to optimize behavior.  In some cases (as with the NIDAQ board we are using), it is problematic if a sequence is not explicitly stopped.  I found this place in the Acquisition Engine optimal to put such a stop in.  It works well with our hardware.  I assume this will not cause problems elsewhere, but not 100% sure.