### PR TITLE
Revert internal variable namin, bump version to 0.39.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.micro-manager.acqengj</groupId>
     <artifactId>AcqEngJ</artifactId>
-    <version>0.39.1</version>
+    <version>0.39.2</version>
     <packaging>jar</packaging>
      <name>AcqEngJ</name>
     <description>Java-based Acquisition engine for Micro-Manager</description>

--- a/src/main/java/org/micromanager/acqj/internal/ZAxis.java
+++ b/src/main/java/org/micromanager/acqj/internal/ZAxis.java
@@ -2,34 +2,34 @@ package org.micromanager.acqj.internal;
 
 public class ZAxis {
 
-   public final double zOriginUm_; //
-   public final double zStepUm_; //
+   public final double zOrigin_um_; //
+   public final double zStep_um_; //
    public final String name_;
    public int exploreLowerZIndexLimit_;
    public int exploreUpperZIndexLimit_;
    public int lowestExploredZIndex_;
    public int highestExploredZIndex_;
 
-   public ZAxis(String name, double zorigin, double zStep) {
+   public ZAxis(String name, double zOrigin, double zStep) {
       name_ = name;
-      zOriginUm_ = zorigin;
-      zStepUm_ = zStep;
+      zOrigin_um_ = zOrigin;
+      zStep_um_ = zStep;
    }
 
-   public ZAxis(String name, double zorigin, double zStep, int exploreLowerLimit,
+   public ZAxis(String name, double zOrigin, double zStep, int exploreLowerLimit,
                 int exploreUpperLimit,
                 int lowestExploredZIndex, int highestExploredZIndex) {
       name_ = name;
-      zOriginUm_ = zorigin;
-      zStepUm_ = zStep;
+      zOrigin_um_ = zOrigin;
+      zStep_um_ = zStep;
       exploreLowerZIndexLimit_ = exploreLowerLimit;
       exploreUpperZIndexLimit_ = exploreUpperLimit;
-      lowestExploredZIndex_ = (int) Math.round((exploreLowerZIndexLimit_ - zOriginUm_) / zStepUm_);
-      highestExploredZIndex_ = (int) Math.round((exploreUpperZIndexLimit_ - zOriginUm_) / zStepUm_);
+      lowestExploredZIndex_ = (int) Math.round((exploreLowerZIndexLimit_ - zOrigin_um_) / zStep_um_);
+      highestExploredZIndex_ = (int) Math.round((exploreUpperZIndexLimit_ - zOrigin_um_) / zStep_um_);
    }
 
    public ZAxis copy() {
-      return new ZAxis(name_, zOriginUm_, zStepUm_, exploreLowerZIndexLimit_,
+      return new ZAxis(name_, zOrigin_um_, zStep_um_, exploreLowerZIndexLimit_,
             exploreUpperZIndexLimit_, lowestExploredZIndex_, highestExploredZIndex_);
    }
 

--- a/src/main/java/org/micromanager/acqj/main/XYTiledAcquisition.java
+++ b/src/main/java/org/micromanager/acqj/main/XYTiledAcquisition.java
@@ -123,11 +123,11 @@ public class XYTiledAcquisition extends Acquisition implements XYTiledAcquisitio
    }
 
    public double getZStep(String name) {
-      return zAxes_.get(name).zStepUm_;
+      return zAxes_.get(name).zStep_um_;
    }
 
    public double getZOrigin(String name) {
-      return zAxes_.get(name).zOriginUm_;
+      return zAxes_.get(name).zOrigin_um_;
    }
 
    public List<String> getZDeviceNames() {


### PR DESCRIPTION
Internal variables are used outside of the package!  This is obviously undesired, but to deal with it now let's revert the names of the affected internal variables.