### PR TITLE
Ignore focus device when setting stages before Z drive

### DIFF
--- a/src/main/java/org/micromanager/acqj/internal/Engine.java
+++ b/src/main/java/org/micromanager/acqj/internal/Engine.java
@@ -814,6 +814,10 @@ public class Engine {
                   tmpEvent = event.getSequence().get(0);
                }
                for (String stageDeviceName : tmpEvent.getStageDeviceNames()) {
+                  // skip z stage since it is handled in a separate function
+                  if(stageDeviceName.equals(core_.getFocusDevice())) {
+                     continue;
+                  }
                   //wait for it to not be busy (is this even needed?)
                   core_.waitForDevice(stageDeviceName);
                   //Move Z


### PR DESCRIPTION
This PR is addressing the issue with focus Z stage going back to origin between steps in Z stack as discussed here https://github.com/micro-manager/micro-manager/issues/2352 and here https://github.com/micro-manager/micro-manager/issues/2360

Focus device is addressed in Z drive function, so we don't need to move it on the previous (set stages) step